### PR TITLE
Migrate knowledge base to gateway API and camelCase schema

### DIFF
--- a/components/EntityView/fields/RichTextField.js
+++ b/components/EntityView/fields/RichTextField.js
@@ -48,6 +48,10 @@ const RichTextField = ({
     rteConfig.multiline :
     maxLength>256;
 
+  const hasContent = Boolean(
+    value && String(value).replace(/<[^>]+>/g, '').trim()
+  );
+
   return (
     <TextField
       className={cxMui(styles.root, className)}
@@ -58,6 +62,11 @@ const RichTextField = ({
       helperText={hasErrors ? errors[0] : description}
       required={required}
       autoFocus={autoFocus}
+      InputLabelProps={{
+        className: styles.inputLabel,
+        // Custom inputComponent (CKEditor) does not update MUI filled state
+        shrink: hasContent ? true : undefined,
+      }}
       InputProps={{
         readOnly: readonly,
         inputComponent : RichTextEditor,

--- a/components/Singularity/store/reducers/knowledgeBase.reducer.js
+++ b/components/Singularity/store/reducers/knowledgeBase.reducer.js
@@ -3,6 +3,23 @@ import { createModel, generateReducer } from '../../../../utilities';
 import { createURLConstraint } from '../../../EntityView/validations/createURLConstraint';
 import { createDateRangeConstraint } from '../../../EntityView/validations/createDateRangeConstraint';
 
+const tagFieldDelimiter = ';';
+
+const tagListFromFieldValue = (value) => {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return value.split(tagFieldDelimiter).map((t) => t.trim()).filter(Boolean);
+};
+
+const tagFieldDisplayValue = (value) => {
+  const tags = tagListFromFieldValue(value);
+  return tags.length > 0 ? tags.join(tagFieldDelimiter) : null;
+};
+
 const definition = createModel({
   name: 'knowledgeBaseItem',
   icon: 'fa book-reader',
@@ -21,7 +38,7 @@ const definition = createModel({
       readonly: true,
     },
     {
-      id: 'clientid',
+      id: 'clientID',
       readonly: true,
       display: false,
       excludeFromModel : true,
@@ -70,17 +87,19 @@ const definition = createModel({
       id: 'tags',
       type: 'tags',
       required: false,
-      minLength: 1,
-      maxLength: 2048,
-      delimiter : ';',
+      delimiter : tagFieldDelimiter,
+      getValue: (entity) => tagFieldDisplayValue(entity.tags),
+      setValue: (entity, valueMap) => ({
+        tags: tagListFromFieldValue(valueMap?.tags),
+      }),
       getOptions : ()=>{
         return {
           definition,
           extractOptions : (entities)=>{
             return entities
               .map(e=>e.tags)
-              .filter(i=>i)
-              .flatMap(i=>i.split(';'))
+              .filter(i=>i && i.length > 0)
+              .flatMap(i=>i)
               .filter((v, i, a)=>a.indexOf(v) === i);
           }
         };
@@ -122,7 +141,7 @@ const definition = createModel({
       maxLength: 65535,
     },
     {
-      id: 'featureimageurl',
+      id: 'featureImageUrl',
       label : 'Feature Image URL',
       description: 'Link to an image representing this feature',
       type: 'imageuri',
@@ -136,7 +155,7 @@ const definition = createModel({
       ],
     },
     {
-      id: 'mediaurl',
+      id: 'mediaUrl',
       type: 'mediauri',
       label : 'Media URL',
       description: 'Link to a demonstration of this feature',
@@ -150,66 +169,66 @@ const definition = createModel({
       ],
     },
     {
-      id: 'includeintips',
+      id: 'includeInTips',
       label: 'Include in Tips',
       description: 'Show this feature in popup tips',
       type: 'boolean',
       default: false,
     },
     {
-      id: 'includeinkb',
+      id: 'includeInKB',
       label: 'Make searchable',
       description: 'Show this feature in the search results',
       type: 'boolean',
       default: true,
     },
     {
-      id: 'includeintour',
+      id: 'includeInTour',
       label: 'Include in Tour',
       description : 'Include this feature in onboarding tours',
       type: 'boolean',
       default: false,
       validations : [(model, field, value)=>{
-        // This is only required if include in tour is set
-        if (model.tourcontrolid && !value) {
+        if (model.tourControlID && !value) {
           return 'required when tour control is set';
-        } else if (!model.tourcontrolid && value) {
+        } else if (!model.tourControlID && value) {
           return 'not allowed if tour control is not set';
         }
       }]
     },
     {
-      id: 'tourcontrolid',
+      id: 'tourControlID',
       label: 'Tour Control ID',
       description: 'The programmatic identifier of an element to link this feature to',
       minLength: 1,
       maxLength: 256,
       validations : [(model, field, value)=>{
-        // This is only required if include in tour is set
-        if (model.includeintour && !value) {
+        if (model.includeInTour && !value) {
           return 'required when included in tour';
-        } else if (!model.includeintour && value) {
+        } else if (!model.includeInTour && value) {
           return 'not allowed if not including in tour';
         }
       }]
     },
     {
-      id: 'authroles',
+      id: 'authRoles',
       label: 'Authorisation Roles',
       type: 'tags',
       description: 'The roles that can see this feature, leave empty for everyone to see',
       required: false,
-      minLength: 1,
-      maxLength: 1024,
-      delimiter : ';',
+      delimiter : tagFieldDelimiter,
+      getValue: (entity) => tagFieldDisplayValue(entity.authRoles),
+      setValue: (entity, valueMap) => ({
+        authRoles: tagListFromFieldValue(valueMap?.authRoles),
+      }),
       getOptions : ()=>{
         return {
           definition,
           extractOptions : (entities)=>{
             return entities
-              .map(e=>e.authroles)
-              .filter(i=>i)
-              .flatMap(i=>i.split(';'))
+              .map(e=>e.authRoles)
+              .filter(i=>i && i.length > 0)
+              .flatMap(i=>i)
               .filter((v, i, a)=>a.indexOf(v) === i);
           }
         };
@@ -222,7 +241,7 @@ const definition = createModel({
       excludeFromModel : true,
     },
     {
-      id: 'additionaldata',
+      id: 'additionalData',
       label: 'Additional Data',
       display: false,
       required: false,
@@ -234,14 +253,14 @@ const definition = createModel({
     'title',
     ['excerpt', ['tags', 'category']],
     'content',
-    ['featureimageurl', 'mediaurl'],
+    ['featureImageUrl', 'mediaUrl'],
     ['start', 'expiry'],
     [
-      ['enabled', 'includeintips'],
-      ['includeinkb'],
-      ['includeintour', 'tourcontrolid']
+      ['enabled', 'includeInTips'],
+      ['includeInKB'],
+      ['includeInTour', 'tourControlID']
     ],
-    'authroles',
+    'authRoles',
   ],
   listLayout: ['title'],
   getReducerRoot: ({ icatalyst }) => {

--- a/components/Singularity/store/reducers/knowledgeBase.reducer.js
+++ b/components/Singularity/store/reducers/knowledgeBase.reducer.js
@@ -24,6 +24,7 @@ const definition = createModel({
   name: 'knowledgeBaseItem',
   icon: 'fa book-reader',
   primaryTextField: 'title',
+  updateMethod: 'patch',
   auth: {
     retrieveAll: 'admin',
     create: 'admin',

--- a/modules/KnowledgeBaseModule/KnowledgeBase/components/FAQComponent.js
+++ b/modules/KnowledgeBaseModule/KnowledgeBase/components/FAQComponent.js
@@ -222,6 +222,9 @@ const FAQComponent = ({
       if (!item) {
         return acc;
       }
+      if (Array.isArray(item)) {
+        return `${acc} ${item.join(' ')}`;
+      }
       const htmlEscapedStr = item.replace(regex, '');
       return `${acc} ${htmlEscapedStr}`;
     }, '');
@@ -234,7 +237,7 @@ const FAQComponent = ({
     return false;
   };
   const faqData = data.filter((item) =>
-    item.includeinkb && applyFilter(item?.title, item?.content, item?.excerpt, item?.tags, item?.category)
+    item.includeInKB && applyFilter(item?.title, item?.content, item?.excerpt, item?.tags, item?.category)
   );
 
   return hasAccess ? (
@@ -295,7 +298,7 @@ const FAQComponent = ({
                 <Grid container className={classes.titleContainer}>
                   <Image
                     className={classes.featureImg}
-                    src={element.featureimageurl}
+                    src={element.featureImageUrl}
                     defaultSrc={placeholderImage}
                   />
                   <Grid className={classes.headerTitle}>
@@ -318,15 +321,15 @@ const FAQComponent = ({
               <AccordionDetails>
                 <div className={cxMui(classes.accordionContent)}>
                   <Grid container>
-                    {element.mediaurl && (
+                    {element.mediaUrl && (
                       <video className={cxMui(classes.accordionVideo)} controls>
-                        <source src={element.mediaurl} type='video/mp4' />
+                        <source src={element.mediaUrl} type='video/mp4' />
                       </video>
                     )}
                     {element.content && (
                       <Grid
                         sm={12}
-                        md={element.mediaurl ? 5 : 10}
+                        md={element.mediaUrl ? 5 : 10}
                         className={cxMui(classes.contentDetail)}
                       >
                         <Typography
@@ -339,10 +342,10 @@ const FAQComponent = ({
                   </Grid>
 
                   <div className={cxMui(classes.tagArea)}>
-                    {element.tags && (
+                    {element.tags?.length > 0 && (
                       <div className={cxMui(classes.accordionChip)}>
                         <Typography variant='subtitle2'>Tags :</Typography>
-                        {element.tags.split(';').map((item) => (
+                        {element.tags.map((item) => (
                           <Chip
                             key={item}
                             label={item}

--- a/services/Singularity/index.js
+++ b/services/Singularity/index.js
@@ -35,6 +35,7 @@ class SingularityService {
     partnerLicenses : 'v2/temp/licenses',
     partnerLicenceKeys : 'v2/temp/licenses/:licenceID/keys',
     session : 'v2/singularity/session',
+    knowledgeBase : 'v2/singularity/knowledge-base-items',
   };
   #urls = {
     authorize : 'authorize',
@@ -45,7 +46,6 @@ class SingularityService {
     edge_type : 'api/edgetype',
     fileUpload : 'api/fileUpload',
     invites : 'api/invite',
-    knowledgeBase : 'v2/api/api/knowledgebaseitems',
     licences : 'v2/api/licences',
     licenceKeys : 'v2/api/licences/:licenceID/keys',
     organisations : 'v2/api/organisations',

--- a/services/Singularity/index.js
+++ b/services/Singularity/index.js
@@ -44,7 +44,7 @@ class SingularityService {
     edge_type : 'api/edgetype',
     fileUpload : 'api/fileUpload',
     invites : 'api/invite',
-    knowledgeBase : 'api/knowledgeBase',
+    knowledgeBase : 'v2/api/api/knowledgebaseitems',
     licences : 'v2/api/licences',
     licenceKeys : 'v2/api/licences/:licenceID/keys',
     organisations : 'v2/api/organisations',


### PR DESCRIPTION
## Summary

Aligns the knowledge base module with the new gateway API and updated response schema. Requests now go through `v2/singularity/knowledge-base-items`, field names match camelCase API properties, and tag fields are handled as arrays rather than semicolon-delimited strings.

## Changes

### Bug fixes
- Route knowledge base CRUD through the gateway endpoint instead of legacy `api/knowledgeBase`.
- Rename model field IDs to camelCase (`featureImageUrl`, `includeInKB`, `authRoles`, etc.) to match the new API response.
- Handle `tags` and `authRoles` as string arrays on read/write; use PATCH for updates.
- Update FAQ search, filtering, and tag chips for array tags and renamed fields.
- Fix rich text field label overlap when CKEditor content is present (MUI filled-state shrink).

### Refactoring
- Add shared helpers to convert tag fields between array and semicolon-delimited form values.

## Recommendations

Agent review of this MR/PR — not stakeholder release content.

### Must fix
- None identified.

### Suggest
- Reuse the tag array/string normalisation helper in FAQ tag chip rendering so stale string responses do not break `.map` on tags.
- Confirm the gateway `v2/singularity/knowledge-base-items` endpoint is deployed before the platform bumps the @icatalyst submodule.
- Consider splitting the RichTextField label fix into a separate PR — it is unrelated to the KB API migration.
- Manually verify KB admin create/edit/delete and FAQ search/display after merge.

## Notes

Platform consumers must bump the @icatalyst submodule to pick up this change. Knowledge base calls require a configured gateway server (already set in platform `applicationConfig`).
