### PR TITLE
Route licence API through Singularity gateway

### DIFF
--- a/components/Singularity/store/reducers/licences.reducer.js
+++ b/components/Singularity/store/reducers/licences.reducer.js
@@ -13,6 +13,7 @@ const definition = createModel({
   identityFieldName: 'guid',
   primaryTextField: 'name',
   secondaryTextField: 'description',
+  updateMethod: 'patch',
   auth: {
     retrieveAll: 'admin',
     create: 'admin',

--- a/services/Singularity/index.js
+++ b/services/Singularity/index.js
@@ -35,6 +35,7 @@ class SingularityService {
     partnerLicenses : 'v2/temp/licenses',
     partnerLicenceKeys : 'v2/temp/licenses/:licenceID/keys',
     session : 'v2/singularity/session',
+    licences : 'v2/singularity/licenses'
   };
   #urls = {
     authorize : 'authorize',
@@ -46,7 +47,6 @@ class SingularityService {
     fileUpload : 'api/fileUpload',
     invites : 'api/invite',
     knowledgeBase : 'api/knowledgeBase',
-    licences : 'v2/api/licences',
     licenceKeys : 'v2/api/licences/:licenceID/keys',
     organisations : 'v2/api/organisations',
     organisationRoles : 'v2/api/organisations/:organisationID/roles',

--- a/services/Singularity/index.js
+++ b/services/Singularity/index.js
@@ -50,7 +50,6 @@ class SingularityService {
     edge_type : 'api/edgetype',
     fileUpload : 'api/fileUpload',
     invites : 'api/invite',
-    licences : 'v2/api/licences',
     licenceKeys : 'v2/api/licences/:licenceID/keys',
     organisations : 'v2/api/organisations',
     organisationRoles : 'v2/api/organisations/:organisationID/roles',

--- a/services/Singularity/index.js
+++ b/services/Singularity/index.js
@@ -35,7 +35,7 @@ class SingularityService {
     partnerLicenses : 'v2/temp/licenses',
     partnerLicenceKeys : 'v2/temp/licenses/:licenceID/keys',
     session : 'v2/singularity/session',
-    licences : 'v2/singularity/licenses'
+    licences : 'v2/singularity/licenses',
     knowledgeBase : 'v2/singularity/knowledge-base-items',
   };
   #urls = {


### PR DESCRIPTION
## Summary

Routes licence management API calls through the Singularity gateway instead of the legacy API path, consistent with the session endpoint migration. Licence updates use PATCH to match the gateway contract.

## Changes

### Refactoring
- Move licence service URL from `v2/api/licences` to `v2/singularity/licenses` on the Singularity gateway.

### Bug fixes
- Set licence model `updateMethod` to `patch` so updates work against the gateway API.

## Recommendations

Agent review of this MR/PR — not stakeholder release content.

### Must fix
- Confirm the gateway exposes `v2/singularity/licenses` (including PATCH for updates) in the environments where this revision will run before the platform bumps the submodule; otherwise licence admin CRUD will fail at runtime.
- Run an end-to-end check on licence admin after deploy: list/create/edit licences on the gateway, then generate and list licence keys (keys still use the legacy `v2/api/licences/:licenceID/keys` host).

### Suggest
- Plan a follow-up to route `licenceKeys` through the gateway when a matching path exists, so licence and key traffic are not split across two API roots.
- Add `updateMethod: 'patch'` on the licence key model too if the gateway expects PATCH for key updates (only licence entity is updated in this PR).
- Record manual QA steps in the ticket (OA-3591) for reviewers: licence CRUD plus generate-key from the organisation licence UI.

## Notes

Coordinate with platform deployment so the gateway licence endpoints are available before this submodule revision is consumed.
