### PR TITLE
chore: migrate invites endpoint to gateway bulk API

### DIFF
--- a/components/Buttons/ResourceSharingButton/index.js
+++ b/components/Buttons/ResourceSharingButton/index.js
@@ -142,6 +142,15 @@ const ResourceSharingButton = ({
           onClosed && onClosed();
         }}
         onSave={(data, callback) => {
+          const RESERVED_RESOURCE_TYPES = {
+            role: 'roles',
+            group: 'groups',
+          };
+
+          const RESOURCE_MAP_OVERRIDES = {
+            framework: 'framework',
+            dashboard: 'dashboard',
+          };
           const buildRelationships = (edgeTypes, start, expiry) => {
             const types = Array.isArray(edgeTypes) ? edgeTypes : [edgeTypes].filter(Boolean);
             return types.map((relationshipTypeID) => {
@@ -152,17 +161,8 @@ const ResourceSharingButton = ({
             });
           };
         
-          const RESERVED_RESOURCE_TYPES = {
-            role: 'roles',
-            group: 'groups',
-          };
-        
           const resourceMapKey = (resourceType) => {
-            const overrides = {
-              framework: 'framework',
-              dashboard: 'dashboard',
-            };
-            return overrides[resourceType] || `${resourceType}s`;
+            return RESOURCE_MAP_OVERRIDES[resourceType] || `${resourceType}s`;
           };
         
           const addEntitlement = (entitlements, resource) => {
@@ -208,11 +208,11 @@ const ResourceSharingButton = ({
         
           const payload = {
             emails,
-            name: data.name,
-            description: data.description,
-            message: data.message,
-            requiresAcknowledgement: true,
+            requiresAcknowledgement: data.requiresAcknowledgement ?? true,
             entitlements,
+            ...(data.name && { name: data.name }),
+            ...(data.description && { description: data.description }),
+            ...(data.message && { message: data.message }),
           };
       
           dispatch(inviteDefinition.operations['BULK_ADD_ENTITIES'](payload, (err, res) => {

--- a/components/Buttons/ResourceSharingButton/index.js
+++ b/components/Buttons/ResourceSharingButton/index.js
@@ -206,23 +206,21 @@ const ResourceSharingButton = ({
         
           const emails = Array.isArray(data.emails) ? data.emails : [data.emails];
         
-          emails.forEach((email) => {
-            const payload = {
-              email,
-              name: data.name,
-              description: data.description,
-              message: data.message,
-              requiresAcknowledgement: true,
-              entitlements,
-            };
-        
-            dispatch(inviteDefinition.operations['ADD_ENTITY'](payload, (err, res) => {
-              callback && callback(err, res);
-              !err && onSaved && onSaved(res);
-            }, {
-              accessToken : accessToken
-            }));
-          });
+          const payload = {
+            emails,
+            name: data.name,
+            description: data.description,
+            message: data.message,
+            requiresAcknowledgement: true,
+            entitlements,
+          };
+      
+          dispatch(inviteDefinition.operations['BULK_ADD_ENTITIES'](payload, (err, res) => {
+            callback && callback(err, res);
+            !err && onSaved && onSaved(res);
+          }, {
+            accessToken : accessToken
+          }));          
         }}
         pageLayouts={[{
           // showTitle : false,

--- a/components/Buttons/ResourceSharingButton/index.js
+++ b/components/Buttons/ResourceSharingButton/index.js
@@ -141,33 +141,88 @@ const ResourceSharingButton = ({
           setShowWizard(false);
           onClosed && onClosed();
         }}
-        onSave={(data, callback)=>{
-          const payload = {
-            emails : data.emails,
-            resources : [
-              {
-                resourceType : data.resourceType,
-                resourceDescription : data.resourceDescription,
-                resourceID : data.resourceID,
-                start : data.start,
-                expiry : data.expiry,
-                edgeTypes : data.edgeTypes
-              },
-              ...additionalResources.map((r)=>{
-                return {
-                  start : data.start,
-                  expiry : data.expiry,
-                  ...r,
-                };
-              })
-            ]
+        onSave={(data, callback) => {
+          const buildRelationships = (edgeTypes, start, expiry) => {
+            const types = Array.isArray(edgeTypes) ? edgeTypes : [edgeTypes].filter(Boolean);
+            return types.map((relationshipTypeID) => {
+              const rel = { relationshipTypeID };
+              if (start != null) rel.starts = start;
+              if (expiry != null) rel.expires = expiry;
+              return rel;
+            });
           };
-          dispatch(inviteDefinition.operations['ADD_ENTITY'](payload, (err, res)=>{
-            callback && callback(err, res);
-            !err && onSaved && onSaved(res);
-          }, {
-            accessToken : accessToken
-          }));
+        
+          const RESERVED_RESOURCE_TYPES = {
+            role: 'roles',
+            group: 'groups',
+          };
+        
+          const resourceMapKey = (resourceType) => {
+            const overrides = {
+              framework: 'framework',
+              dashboard: 'dashboard',
+            };
+            return overrides[resourceType] || `${resourceType}s`;
+          };
+        
+          const addEntitlement = (entitlements, resource) => {
+            const { resourceType, resourceDescription, resourceID, start, expiry, edgeTypes } = resource;
+            const relationships = buildRelationships(edgeTypes, start, expiry);
+            const isReservedResourceType = RESERVED_RESOURCE_TYPES[resourceType];
+        
+            if (isReservedResourceType) {
+              entitlements[isReservedResourceType] = entitlements[isReservedResourceType] || [];
+              entitlements[isReservedResourceType].push({ id: resourceID, relationships });
+            } else {
+              const mapKey = resourceMapKey(resourceType);
+              entitlements.resourceMap = entitlements.resourceMap || {};
+              entitlements.resourceMap[mapKey] = entitlements.resourceMap[mapKey] || [];
+              entitlements.resourceMap[mapKey].push({
+                resourceID,
+                ...(resourceDescription ? { resourceDescription } : {}),
+                relationships,
+              });
+            }
+          };
+        
+          const entitlements = {};
+        
+          addEntitlement(entitlements, {
+            resourceType: data.resourceType,
+            resourceDescription: data.resourceDescription,
+            resourceID: data.resourceID,
+            start: data.start,
+            expiry: data.expiry,
+            edgeTypes: data.edgeTypes,
+          });
+        
+          additionalResources.forEach((r) => {
+            addEntitlement(entitlements, {
+              start: data.start,
+              expiry: data.expiry,
+              ...r,
+            });
+          });
+        
+          const emails = Array.isArray(data.emails) ? data.emails : [data.emails];
+        
+          emails.forEach((email) => {
+            const payload = {
+              email,
+              name: data.name,
+              description: data.description,
+              message: data.message,
+              requiresAcknowledgement: true,
+              entitlements,
+            };
+        
+            dispatch(inviteDefinition.operations['ADD_ENTITY'](payload, (err, res) => {
+              callback && callback(err, res);
+              !err && onSaved && onSaved(res);
+            }, {
+              accessToken : accessToken
+            }));
+          });
         }}
         pageLayouts={[{
           // showTitle : false,

--- a/components/Buttons/ResourceSharingButton/index.js
+++ b/components/Buttons/ResourceSharingButton/index.js
@@ -166,7 +166,7 @@ const ResourceSharingButton = ({
           };
         
           const addEntitlement = (entitlements, resource) => {
-            const { resourceType, resourceDescription, resourceID, start, expiry, edgeTypes } = resource;
+            const { resourceType, resourceID, start, expiry, edgeTypes } = resource;
             const relationships = buildRelationships(edgeTypes, start, expiry);
             const isReservedResourceType = RESERVED_RESOURCE_TYPES[resourceType];
         
@@ -179,7 +179,6 @@ const ResourceSharingButton = ({
               entitlements.resourceMap[mapKey] = entitlements.resourceMap[mapKey] || [];
               entitlements.resourceMap[mapKey].push({
                 resourceID,
-                ...(resourceDescription ? { resourceDescription } : {}),
                 relationships,
               });
             }
@@ -189,7 +188,6 @@ const ResourceSharingButton = ({
         
           addEntitlement(entitlements, {
             resourceType: data.resourceType,
-            resourceDescription: data.resourceDescription,
             resourceID: data.resourceID,
             start: data.start,
             expiry: data.expiry,
@@ -205,13 +203,16 @@ const ResourceSharingButton = ({
           });
         
           const emails = Array.isArray(data.emails) ? data.emails : [data.emails];
+          const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+          const inviteExpiry = Date.now() + SEVEN_DAYS_MS;          
         
           const payload = {
             emails,
+            expires: inviteExpiry,
             requiresAcknowledgement: data.requiresAcknowledgement ?? true,
             entitlements,
-            ...(data.name && { name: data.name }),
-            ...(data.description && { description: data.description }),
+            name: data.name || primaryText,
+            ...(data.resourceDescription && { description: data.resourceDescription }),
             ...(data.message && { message: data.message }),
           };
       

--- a/components/Singularity/store/actions/invites.actions.js
+++ b/components/Singularity/store/actions/invites.actions.js
@@ -1,11 +1,39 @@
 import {generateActions} from '../../../../utilities/generateActions';
-import {generateOperations} from '../../../../utilities/generateOperations';
+import {createURI, generateOperations, makeReducerRequest, parseToken} from '../../../../utilities/generateOperations';
 import URIService from '../../../../services/URIService';
 
 export const actions = generateActions('invitations');
 
-export const operations = generateOperations({
+const ops = generateOperations({
   uri : ()=>{
     return URIService.getURI('singularity', 'invites');
   }
 }, actions);
+
+ops['BULK_ADD_ENTITIES'] = (data, callback, requestConfig = {})=>{
+  const {
+    params,
+  } = requestConfig;
+
+  const url = createURI(
+    `${URIService.getURI('singularity', 'invites')}/bulk`,
+    params
+  );
+
+  return makeReducerRequest({
+    method : 'post',
+    url,
+    headers : {
+      Authorization : parseToken(requestConfig),
+      'Content-Type': 'application/json',
+    },
+    data,
+    transform : requestConfig.transform,
+  },
+  'ENTITY_ADDED',
+  'ENTITY_ADDED_ERROR',
+  callback
+  );
+};
+export const operations = ops;
+

--- a/components/Singularity/store/actions/invites.actions.js
+++ b/components/Singularity/store/actions/invites.actions.js
@@ -30,8 +30,8 @@ ops['BULK_ADD_ENTITIES'] = (data, callback, requestConfig = {})=>{
     data,
     transform : requestConfig.transform,
   },
-  'ENTITY_ADDED',
-  'ENTITY_ADDED_ERROR',
+  actions['ENTITY_ADDED'],
+  actions['ENTITY_ADDED_ERROR'],
   callback
   );
 };

--- a/components/Singularity/store/reducers/invites.reducer.js
+++ b/components/Singularity/store/reducers/invites.reducer.js
@@ -11,6 +11,7 @@ const definition = createModel({
   name: 'invite',
   icon: 'contact_mail',
   canAdd : false,
+  updateMethod: 'patch',
   auth: {
     retrieveAll : 'admin',
     // create : 'admin',

--- a/services/Singularity/index.js
+++ b/services/Singularity/index.js
@@ -46,13 +46,13 @@ class SingularityService {
     personalAccessToken : 'v2/singularity/personal-access-tokens',
     client_data : 'v2/singularity/client-data',
     client : 'v2/singularity/clients',
+    invites : 'v2/singularity/invites',
   };
   #urls = {
     authorize : 'authorize',
     authProviders: 'v2/api/authProviders',
     changePassword : 'changePassword',
     fileUpload : 'api/fileUpload',
-    invites : 'api/invite',
     organisationRoles : 'v2/api/organisations/:organisationID/roles',
     organisationStats : 'v2/api/organisations/:organisationID/stats',
     organisationUsers : 'v2/api/organisations/:organisationID/users',


### PR DESCRIPTION
## Summary

Migrates Singularity invites from the legacy `api/invite` path to the API gateway (`v2/singularity/invites`) and switches resource sharing to the bulk invites endpoint with an entitlements payload. Follow-up commits address review feedback, set a default invite expiry, fix Redux list refresh after bulk send, and pick up the notifications gateway path from `dev`.

## Changes

### Features
- Resource sharing sends invites via `POST …/invites/bulk` with an entitlements structure (roles, groups, resource map) instead of a flat `resources` array.
- Bulk payload includes invite-level `expires` (default 7 days), `requiresAcknowledgement` (defaults to true), `name` (falls back to resource title), and optional `description` / `message`.

### Bug fixes
- Fixed invite list not refreshing after send: `BULK_ADD_ENTITIES` now dispatches namespaced `ENTITY_ADDED` action types instead of plain string literals.
- Set invite model `updateMethod` to `patch` for gateway-aligned updates.
- Removed `resourceDescription` from entitlement entries; map invite `description` from wizard `resourceDescription` at the top level.

### Refactoring
- Moved invites URI from legacy `api/invite` to `v2/singularity/invites` in Singularity service config.
- Added custom `BULK_ADD_ENTITIES` operation; refactored ResourceSharingButton to build entitlements from primary and additional resources.
- Moved notifications URI from `v2/api/notification` to `v2/singularity/notifications` (merged from `dev`).

## Recommendations

Agent review of this MR/PR — not stakeholder release content.

### Must fix
- None identified.

### Suggest
- `CreateInvitation.js` still uses `ADD_ENTITIES` (sequential legacy per-invite POSTs). Confirm the gateway still accepts that contract on `v2/singularity/invites`, or migrate that flow to bulk/entitlements.
- Invite-level `expires` is hardcoded to 7 days while relationship `start`/`expiry` still come from the wizard — confirm product intent if those should stay aligned.
- Verify bulk API response shape matches what `ENTITY_ADDED` expects (identity field per invite) so list refresh works for multi-email sends, not only single-invite responses.
- Entitlement-building logic remains inline in ResourceSharingButton — consider extracting for unit tests.

## Notes

Coordinate platform deployment with gateway availability for `v2/singularity/invites`, `/bulk`, and `v2/singularity/notifications`. Smoke-test resource sharing (multi-email), invites list refresh, and org-level invitation creation from User Management.
