### PR TITLE
fix: changed notification endpoint to gateway

### DIFF
--- a/services/Singularity/index.js
+++ b/services/Singularity/index.js
@@ -46,6 +46,7 @@ class SingularityService {
     personalAccessToken : 'v2/singularity/personal-access-tokens',
     client_data : 'v2/singularity/client-data',
     client : 'v2/singularity/clients',
+    notification : 'v2/singularity/notifications',
   };
   #urls = {
     authorize : 'authorize',
@@ -58,7 +59,6 @@ class SingularityService {
     organisationUsers : 'v2/api/organisations/:organisationID/users',
     organisationEntitySettings : 'v2/api/platform/organisations/:organisationID/entity-settings',
     profile : 'api/profile',
-    notification : 'v2/api/notification',
     roleMembers: 'v2/api/roles/:roleID/relationships',
     roleMemberRelationships: 'v2/api/roles/:roleID/relationships/:resourceID',
     roleMemberUserRelationships: 'v2/api/roles/:roleID/relationships/:action',


### PR DESCRIPTION
## Summary

Routes Singularity notification API calls through the Sensemaker API gateway instead of the legacy Singularity server. Framework notification requests in the platform will resolve to `v2/singularity/notifications` on the gateway host, consistent with other recent Singularity endpoint migrations.

## Changes

### Bug fixes
- Move the `notification` URI from legacy `v2/api/notification` on the Singularity server to gateway path `v2/singularity/notifications`.

## Recommendations

Agent review of this MR/PR — not stakeholder release content.

### Must fix
- None identified.

### Suggest
- Confirm the gateway route `v2/singularity/notifications` is deployed and matches the plural path (legacy route was singular `notification`) before the platform bumps the @icatalyst submodule.
- Rename the PR/commit from "resolved merge conflict" to match the gateway-migration convention used in recent PRs (e.g. "fix: changed notification endpoint to gateway").

## Notes

Platform consumers (e.g. framework notifications via `URIService.getURI('singularity', 'notification')`) pick up the new URL when @icatalyst is bumped on dev. No caller changes are required in icatalyst beyond the URI map update.
